### PR TITLE
Remove '\n' chars from encoded Auth string.

### DIFF
--- a/tincan/remote_lrs.py
+++ b/tincan/remote_lrs.py
@@ -81,6 +81,10 @@ class RemoteLRS(Base):
                                                          ":" +
                                                          unicode(kwargs["password"]))[:-1]
 
+	    # If username and password are long, the base64 encoded string might have one or more '\n' chars
+            # we need to remove them
+            auth_string = "".join(auth_string.split('\n'))
+
             kwargs.pop("username")
             kwargs.pop("password")
             kwargs["auth"] = auth_string


### PR DESCRIPTION
I used this library against Learning Locker, which uses long usernames and passwords for basic auth (40 chars each). I observed that the base64.encoded string contains not only a '\n' at the end, but also one in the middle the string. This causes the http Auth header to be broken, and the LRS responds with a 400 bad request, so I added that one line to remove all '\n' that might exist it the auth_string.