### PR TITLE
Fix broken basic auth with long username/password

### DIFF
--- a/tincan/remote_lrs.py
+++ b/tincan/remote_lrs.py
@@ -77,9 +77,9 @@ class RemoteLRS(Base):
                 and kwargs["password"] is not None \
                 and "auth" not in kwargs:
             # The base64 encode tacks on a \n character to the string which needs to be removed.
-            auth_string = "Basic " + base64.encodestring(unicode(kwargs["username"]) +
-                                                         ":" +
-                                                         unicode(kwargs["password"]))[:-1]
+            auth_string = "Basic " + base64.b64encode(unicode(kwargs["username"]) +
+                                                      ":" +
+                                                      unicode(kwargs["password"]))
 
             kwargs.pop("username")
             kwargs.pop("password")


### PR DESCRIPTION
With long usernames and passwords (like those produced by Learning
Locker), the base64.encodestring produces multiline digest for the Auth
header, thus breaking the requests. This patch uses the better
b64encode, which doesn't add any spurious newlines.