### PR TITLE
Added support for RemoteLRS.timeout

### DIFF
--- a/examples/example_script.py
+++ b/examples/example_script.py
@@ -21,6 +21,7 @@ print("constructing the LRS...")
 lrs = RemoteLRS(
     version=lrs_properties.version,
     endpoint=lrs_properties.endpoint,
+    timeout=lrs_properties.timeout,
     username=lrs_properties.username,
     password=lrs_properties.password,
 )

--- a/test/remote_lrs_test.py
+++ b/test/remote_lrs_test.py
@@ -54,12 +54,14 @@ from tincan.documents import (
 class RemoteLRSTest(unittest.TestCase):
     def setUp(self):
         self.endpoint = lrs_properties.endpoint
+        self.timeout = lrs_properties.timeout
         self.version = lrs_properties.version
         self.username = lrs_properties.username
         self.password = lrs_properties.password
         self.lrs = RemoteLRS(
             version=self.version,
             endpoint=self.endpoint,
+            timeout=self.timeout,
             username=self.username,
             password=self.password,
         )
@@ -126,6 +128,7 @@ class RemoteLRSTest(unittest.TestCase):
         lrs = RemoteLRS()
         self.assertIsInstance(lrs, RemoteLRS)
         self.assertIsNone(lrs.endpoint)
+        self.assertIsNone(lrs.timeout)
         self.assertIsNone(lrs.auth)
         self.assertEqual(Version.latest, lrs.version)
 
@@ -141,6 +144,10 @@ class RemoteLRSTest(unittest.TestCase):
         response = lrs.about()
 
         self.assertFalse(response.success)
+
+    def test_operation_without_timeout(self):
+        self.lrs.timeout = None
+        self.test_about()
 
     def test_save_statement(self):
         statement = Statement(

--- a/test/resources/lrs_properties.py.template
+++ b/test/resources/lrs_properties.py.template
@@ -4,6 +4,7 @@ Contains user-specific information for testing.
 
 
 endpoint = "<endpoint>"
+timeout = <timeout> # an optional timeout in seconds
 version = "<valid_version>" # 1.0.1 | 1.0.0 | 0.95 | 0.9
 username = "<username>"
 password = "<password>"


### PR DESCRIPTION
Making it possible to override the default platform socket timeout with
an explicit 'timeout' property. This is useful when making requests
against an unresponsive LRS in a time-sensitive environment.